### PR TITLE
Espresso test coverage for listing fragment

### DIFF
--- a/app/src/androidTest/java/com/hackernewsapplication/AbsListViewMatcher.kt
+++ b/app/src/androidTest/java/com/hackernewsapplication/AbsListViewMatcher.kt
@@ -1,0 +1,20 @@
+package com.hackernewsapplication
+
+import android.view.View
+import androidx.test.espresso.matcher.BoundedMatcher
+import com.hackernewsapplication.common.customviews.CustomVerticalRecyclerView
+import org.hamcrest.Description
+
+class AbsListViewMatcher() : BoundedMatcher<View, CustomVerticalRecyclerView>(CustomVerticalRecyclerView::class.java) {
+
+    override fun describeTo(description: Description?) {
+
+    }
+
+    override fun matchesSafely(item: CustomVerticalRecyclerView?): Boolean = run {
+        val adapterCount = item?.adapter?.itemCount ?: -1
+        adapterCount > 0
+    }
+
+
+}

--- a/app/src/androidTest/java/com/hackernewsapplication/android/fragments/ListingFragmentTest.kt
+++ b/app/src/androidTest/java/com/hackernewsapplication/android/fragments/ListingFragmentTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.runner.AndroidJUnit4
+import com.hackernewsapplication.AbsListViewMatcher
 import com.hackernewsapplication.android.R
 import com.hackernewsapplication.android.view.listing.viewholder.NewsListingItemViewHolder
 import org.hamcrest.Description
@@ -56,6 +57,17 @@ class ListingFragmentTest {
                 .perform(RecyclerViewActions.actionOnItemAtPosition<NewsListingItemViewHolder>(0, click()))
         }
 
+    }
+
+    @Test
+    fun list_has_items_on_view() {
+        with(FragmentScenario.launchInContainer(ListingFragment::class.java)) {
+            onFragment {
+                IdlingRegistry.getInstance().register(it.idlingResource())
+                it.idlingResource()?.increment()
+            }
+            onView(withId(R.id.base_listing)).check(matches(AbsListViewMatcher()))
+        }
     }
 
     @After


### PR DESCRIPTION
[Reason] Test coverage for checking if item is  displayed in recyclerview after api call

[Solution]
     Added custom viewmatcher logic rather than usage of junit assert which causes assertionError for 
     espresso test.